### PR TITLE
Fixes some errors, adds some more to readme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,9 @@ sonica_pb2_grpc.py
 sonica_pb2.py
 sonica.pb.cr
 sonica_services.pb.cr
+
+# Files created when installing crystal and shards locally
+bin/
+lib/
+shard.lock
+shard.yml

--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,7 @@ sonica.pb.cr
 sonica_services.pb.cr
 
 # Files created when installing crystal and shards locally
-bin/
-lib/
-shard.lock
-shard.yml
+/bin/
+/lib/
+/shard.lock
+/shard.yml

--- a/README.md
+++ b/README.md
@@ -12,7 +12,22 @@ Client software then communicates with the daemon via gRPC (or in the case of th
 
 Each client and the daemon has their own README with build information and the like.
 
+
+## Installation 
 To work on *any* part of Sonica, the `prepare.py` script is needed to generate gRPC code for the language. To get started with the `discord` client, just run `./prepare.py discord`. 
 This requires the python packages from the `requirements.txt` in the root, as well as `protoc` needing to be in the path. (Check the [gRPC web page](https://grpc.io/) for info on how to install it on your platform)
 The easiest way to work on Sonica is to use the `nix` package manager, as all parts of Sonica has shells set up, so only `nix-shell` is needed for development.
 
+### Arch-specific installation
+To get everything working on Arch and Arch-derived distributions, follow the following steps:
+
+1. Install the `crystal` and `shards` packages from the Arch repositories
+2. In a terminal, navigate to the root directory of the Sonica repo
+3. Run `shards init`
+4. Run `echo -e "dependencies:\n  logger:\n    github: crystal-lang/logger.cr\n  grpc:\n    github: jgaskins/grpc" >> shard.yml`
+5. Run `shards install` and then restart your shell
+
+From here, you can start install requirements and preparing specific installation modules. For python-based modules (such as `discord` and `daemon`):
+1. Run `python -m venv venv`, and then active the virtual environment, if you want to use a virtual environment.
+2. Run `python -m pip install --upgrade pip` followed by `pip install -r requirements.txt`
+3. For each `[MODULE]` you wish to work on, run `pip install -r [MODULE]/requirements.txt`, then `python prepare.py --protoc-gen-crystal ./bin/protoc-gen-crystal --protoc-gen-grpc ./bin/grpc_crystal [MODULE]`

--- a/discord/sonica-discord.py
+++ b/discord/sonica-discord.py
@@ -10,6 +10,8 @@ from sonica_pb2 import Empty
 
 bot = commands.Bot(command_prefix='')
 channel = grpc.insecure_channel('localhost:7700')
+print("Trying to connect to Sonica daemon...")
+# TODO: Implement some timeout wait if the daemon isn't running or something goes wrong
 daemon = SonicaStub(channel)
 
 @bot.command()
@@ -17,7 +19,13 @@ async def play(ctx):
     res = daemon.Play(Empty())
     await ctx.message.channel.send(f'result: {str(res.success)}')
 
+
+@bot.event
+async def on_ready():
+    print(f"Logged on as {bot.user}!")
+
 def main(token : str):
+    print("Logging in...")
     bot.run(token)
 
 typer.run(main)

--- a/prepare.py
+++ b/prepare.py
@@ -85,7 +85,6 @@ def callback(
         options["protoc_gen_crystal"] = protoc_gen_crystal
 
     if protoc_gen_grpc == "":
-        op
         error("PROTOC_GEN_GRPC needs to be given as an option or be in the environment\n" + crystal_url)
     else:
         options["protoc_gen_grpc"] = protoc_gen_grpc

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+grpcio
+grpcio-tools


### PR DESCRIPTION
- A typo in `prepare.py` has been fixed.
- Feedback about Discord!Sonica's progress for logging in has been added.
- Readme has been expanded to add Arch-specific documentation for how to install grpcio and preparing the python modules
- Gitignore has been expanded to include folders and files created through Crystal and its package manager Shards
- `requirements.txt` has been added for the root folder, though it's mostly to make sure that `grpcio-tools` also has been installed through pip.